### PR TITLE
remove Hawkbit/MQTT sample

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,8 +13,6 @@
             revision="6c34268e203d23bbfbfda3f7362dac8b9b9382bc"
             path="mcuboot/sim/mcuboot-sys/mbedtls" />
 
-  <project name="dm-hawkbit-mqtt"
-           path="zephyr-fota-samples/dm-hawkbit-mqtt"/>
   <project name="dm-lwm2m"
            path="zephyr-fota-samples/dm-lwm2m"/>
   <project name="dm-lwm2m-light"


### PR DESCRIPTION
We are removing the Hawkbit/MQTT sample due to:
- effort needed to update to new socket-based code
- no one is using it

Change-Id: Ib0eb3b32ae6f1ab3a040ff213e205b3110e5d2f0
Signed-off-by: Michael Scott <mike@foundries.io>