### PR TITLE
west: pin to v38 temporarily

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -29,6 +29,7 @@
   <project name="zmp-prebuilt"
            clone-depth="1"
            path="zmp-build/other/zmp-prebuilt"/>
-  <project name="west"
+  <!-- Temporarily pin west to release 38 while we migrate -->
+  <project name="west" revision="refs/tags/mp-38"
            path="zmp-build/other/west"/>
 </manifest>


### PR DESCRIPTION
We need to pin west to a slightly older version to avoid making
changes to our workflow during the heavy ZmP v39 release cycle.

Once we update documentation and can move to using west for the
normal workflow, this commit can be reverted.

Change-Id: Ib98261b09a2b1e95cb2dfdd9c90e30793f9825d6
Signed-off-by: Michael Scott <mike@foundries.io>