### PR TITLE
[temphack] requirements: pin cryptography to version 2.5 to fix break

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+cryptography==2.5
 imgtool


### PR DESCRIPTION
Cryptography 2.6 has a pip related bug which can break installations:
https://github.com/pyca/cryptography/pull/4783

Will revert this once fixed.

Signed-off-by: Michael Scott <mike@foundries.io>