### PR TITLE
manifest: add tinycbor external Zephyr git (module)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,13 +12,14 @@ manifest:
       url-base: https://github.com/foundriesio
 
   projects:
-    # Zephyr and MCUboot
+    # Zephyr, MCUboot and related modules
     - name: zephyr
       west-commands: scripts/west-commands.yml
     - name: mcuboot
     - name: mbedtls
       path: mcuboot/sim/mcuboot-sys/mbedtls
       revision: 60fbd5bdf05c223b641677204469b53c2ff39d4e
+    - name: tinycbor
 
     # Sample apps; just one for now
     - name: dm-lwm2m


### PR DESCRIPTION
tinycbor was moved out of the main Zephyr repository as the first
step towards managing external dependencies as Zephyr modules.

More will probably follow.

Signed-off-by: Michael Scott <mike@foundries.io>