### PR TITLE
requirements: bump cryptography to 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography==2.5
+cryptography==2.7
 imgtool


### PR DESCRIPTION
This is now required by mcuboot.

Signed-off-by: Michael Scott <mike@foundries.io>